### PR TITLE
Fix compilation issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <resources>
       <resource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/..</directory>
+        <directory>${basedir}/../uap-core</directory>
         <includes>
           <include>regexes.yaml</include>
         </includes>
@@ -23,7 +23,14 @@
     <testResources>
       <testResource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/../test_resources</directory>
+        <directory>${basedir}/../uap-core/test_resources</directory>
+        <includes>
+          <include>*.yaml</include>
+        </includes>
+      </testResource>
+      <testResource>
+        <targetPath>ua_parser</targetPath>
+        <directory>${basedir}/../uap-core/tests</directory>
         <includes>
           <include>*.yaml</include>
         </includes>

--- a/src/test/java/ua_parser/ParserTest.java
+++ b/src/test/java/ua_parser/ParserTest.java
@@ -45,12 +45,12 @@ public class ParserTest {
 
   @Test
   public void testParseUserAgent() {
-    testUserAgentFromYaml("test_user_agent_parser.yaml");
+    testUserAgentFromYaml("test_ua.yaml");
   }
 
   @Test
   public void testParseOS() {
-    testOSFromYaml("test_user_agent_parser_os.yaml");
+    testOSFromYaml("test_os.yaml");
   }
 
   @Test


### PR DESCRIPTION
These tests are necessary in order for uap-java to compile with the latest version of uap-core.

The new github project is named 'uap-core' so I've changed the pom.xml to assume that this directory exists as a sibling to uap-java in the filesystem. In addition the filenames some of the test .yaml files have moved around in the uap-core project so I've updated these test in this project.