### PR TITLE
optimizing CachingParser

### DIFF
--- a/src/main/java/ua_parser/Parser.java
+++ b/src/main/java/ua_parser/Parser.java
@@ -45,8 +45,8 @@ public class Parser {
   }
 
   public Client parse(String agentString) {
-    UserAgent ua = parseUserAgent(agentString);
-    OS os = parseOS(agentString);
+    UserAgent ua = uaParser.parse(agentString);
+    OS os = osParser.parse(agentString);
     Device device = deviceParser.parse(agentString);
     return new Client(ua, os, device);
   }


### PR DESCRIPTION
When using the method CachingParser.parse(), useless caching is done :

The CachingParser.parse() uses a cache, then calls its parent Parser.parse() method, which calls Parser.parseUserAgent(), which is overriden by CachingParser.parseUserAgent() wich uses a second cache.

The same holds for parseOS().