### PR TITLE
make uap-core as git submodule of uap-java. add hive support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "uap-core"]
+	path = uap-core
+	url = https://github.com/ua-parser/uap-core.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ua_parser Java Library
 ======================
 
-This is the Java implementation of [ua-parser](https://github.com/tobie/ua-parser).
+This is the Java implementation of [ua-parser](https://github.com/ua-parser/uap-core).
 The implementation uses the shared regex patterns and overrides from regexes.yaml.
 
 Build:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,22 @@ import ua_parser.Client;
 
   System.out.println(c.device.family);    // => "iPhone"
 ```
-
+in Hive: (copy ua-parser.jar into your CLASSPATH, and create function)
+```sql
+-- add jar to classpath
+add jar ua-parser.jar;
+-- create function
+CREATE TEMPORARY FUNCTION parse_agent as 'ua_parser.hive.ParseAgent';
+-- count visits
+SELECT parsed_agent['os_family'] AS os_family, COUNT(*) AS cnt
+FROM (
+  SELECT parse_agent(user_agent) AS parsed_agent
+  FROM table_name
+  WHERE date='today'
+) x
+GROUP BY parsed_agent['os_family']
+ORDER BY cnt DESC LIMIT 1000;
+```
 Author:
 -------
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,15 +6,16 @@
   <packaging>jar</packaging>
   <version>1.3.1-SNAPSHOT</version>
   <name>ua-parser</name>
-  <url>https://github.com/tobie/ua-parser/</url>
+  <url>https://github.com/ua-parser/uap-java/</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <hive.version>2.0.0</hive.version>
   </properties>
   <build>
     <resources>
       <resource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/../uap-core</directory>
+        <directory>${basedir}/uap-core</directory>
         <includes>
           <include>regexes.yaml</include>
         </includes>
@@ -23,14 +24,14 @@
     <testResources>
       <testResource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/../uap-core/test_resources</directory>
+        <directory>${basedir}/uap-core/test_resources</directory>
         <includes>
           <include>*.yaml</include>
         </includes>
       </testResource>
       <testResource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/../uap-core/tests</directory>
+        <directory>${basedir}/uap-core/tests</directory>
         <includes>
           <include>*.yaml</include>
         </includes>
@@ -81,6 +82,12 @@
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>3.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-exec</artifactId>
+      <version>${hive.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>ua_parser</groupId>
   <artifactId>ua-parser</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <name>ua-parser</name>
   <url>https://github.com/ua-parser/uap-java/</url>
   <properties>
@@ -55,6 +55,26 @@
           <execution>
             <id>attach-sources</id>
             <goals><goal>jar</goal></goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>hive</shadedClassifierName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+              </transformers>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/ua_parser/CachingParser.java
+++ b/src/main/java/ua_parser/CachingParser.java
@@ -1,16 +1,9 @@
 package ua_parser;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
 import org.apache.commons.collections.map.LRUMap;
-
-import ua_parser.Client;
-import ua_parser.Device;
-import ua_parser.OS;
-import ua_parser.Parser;
-import ua_parser.UserAgent;
 
 /**
  * When doing webanalytics (with for example PIG) the main pattern is to process
@@ -37,7 +30,7 @@ public class CachingParser extends Parser {
 
   // ------------------------------------------
 
-  public CachingParser() throws IOException {
+  public CachingParser() {
     super();
   }
 

--- a/src/main/java/ua_parser/Parser.java
+++ b/src/main/java/ua_parser/Parser.java
@@ -36,8 +36,15 @@ public class Parser {
   private OSParser osParser;
   private DeviceParser deviceParser;
 
-  public Parser() throws IOException {
-    this(Parser.class.getResourceAsStream(REGEX_YAML_PATH));
+  public Parser() {
+    InputStream regexYaml = Parser.class.getResourceAsStream(REGEX_YAML_PATH);
+    try {
+      initialize(regexYaml);
+    } finally {
+      try {
+        regexYaml.close();
+      } catch (IOException ignored) {}
+    }
   }
 
   public Parser(InputStream regexYaml) {

--- a/src/main/java/ua_parser/hive/Parse.java
+++ b/src/main/java/ua_parser/hive/Parse.java
@@ -12,10 +12,10 @@ import ua_parser.Parser;
 /**
  * @author fanliwen
  */
-@Description(name="pase_agent",
+@Description(name="parse",
         value="_FUNC_ returns Map, which has keys such as 'os_family', 'os_major', 'os_minor', 'device', 'ua_family', 'ua_major' and 'ua_minor'.",
         extended="_FUNC_(user_agent_string)")
-public final class ParseAgent extends UDF {
+public final class Parse extends UDF {
 
     private static final Parser PARSER = new Parser();
 

--- a/src/main/java/ua_parser/hive/ParseAgent.java
+++ b/src/main/java/ua_parser/hive/ParseAgent.java
@@ -1,0 +1,44 @@
+package ua_parser.hive;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.io.Text;
+import ua_parser.Client;
+import ua_parser.Parser;
+
+/**
+ * @author fanliwen
+ */
+@Description(name="pase_agent",
+        value="_FUNC_ returns Map, which has keys such as 'os_family', 'os_major', 'os_minor', 'device', 'ua_family', 'ua_major' and 'ua_minor'.",
+        extended="_FUNC_(user_agent_string)")
+public final class ParseAgent extends UDF {
+
+    private static final Parser PARSER = new Parser();
+
+    public Map<String,String> evaluate(final Text s) {
+        Client client = PARSER.parse(s == null ? null : s.toString());
+
+        Map<String, String> map = new HashMap<String, String>(10);
+        if (client.os != null) {
+            map.put("os_family", client.os.family);
+            map.put("os_major", client.os.major);
+            map.put("os_minor", client.os.minor);
+            map.put("os_patch", client.os.patch);
+            map.put("os_patchMinor", client.os.patchMinor);
+        }
+        if (client.device != null) {
+            map.put("device", client.device.family);
+        }
+        if (client.userAgent != null) {
+            map.put("ua_family", client.userAgent.family);
+            map.put("ua_major", client.userAgent.major);
+            map.put("ua_minor", client.userAgent.minor);
+            map.put("ua_patch", client.userAgent.patch);
+        }
+        return map;
+    }
+}

--- a/src/main/java/ua_parser/hive/ParseDevice.java
+++ b/src/main/java/ua_parser/hive/ParseDevice.java
@@ -1,0 +1,32 @@
+package ua_parser.hive;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.io.Text;
+
+import ua_parser.Device;
+import ua_parser.Parser;
+
+/**
+ * @author fanliwen
+ */
+@Description(name="parse_device",
+        value="_FUNC_ returns Map, which has keys such as 'device'.",
+        extended="_FUNC_(user_agent_string)")
+public class ParseDevice extends UDF {
+
+    private static final Parser PARSER = new Parser();
+
+    public Map<String,String> evaluate(final Text s) {
+        Device device = PARSER.parseDevice(s == null ? null : s.toString());
+
+        Map<String, String> map = new HashMap<String, String>(1);
+        if (device != null) {
+            map.put("device", device.family);
+        }
+        return map;
+    }
+}

--- a/src/main/java/ua_parser/hive/ParseOS.java
+++ b/src/main/java/ua_parser/hive/ParseOS.java
@@ -1,0 +1,36 @@
+package ua_parser.hive;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.io.Text;
+
+import ua_parser.OS;
+import ua_parser.Parser;
+
+/**
+ * @author fanliwen
+ */
+@Description(name="parse_os",
+        value="_FUNC_ returns Map, which has keys such as 'os_family', 'os_major', 'os_minor'.",
+        extended="_FUNC_(user_agent_string)")
+public class ParseOS extends UDF {
+
+    private static final Parser PARSER = new Parser();
+
+    public Map<String,String> evaluate(final Text s) {
+        OS os = PARSER.parseOS(s == null ? null : s.toString());
+
+        Map<String, String> map = new HashMap<String, String>(5);
+        if (os != null) {
+            map.put("os_family", os.family);
+            map.put("os_major", os.major);
+            map.put("os_minor", os.minor);
+            map.put("os_patch", os.patch);
+            map.put("os_patchMinor", os.patchMinor);
+        }
+        return map;
+    }
+}

--- a/src/main/java/ua_parser/hive/ParseUserAgent.java
+++ b/src/main/java/ua_parser/hive/ParseUserAgent.java
@@ -1,0 +1,35 @@
+package ua_parser.hive;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.io.Text;
+
+import ua_parser.Parser;
+import ua_parser.UserAgent;
+
+/**
+ * @author fanliwen
+ */
+@Description(name="parse_user_agent",
+        value="_FUNC_ returns Map, which has keys such as 'ua_family', 'ua_major' and 'ua_minor'.",
+        extended="_FUNC_(user_agent_string)")
+public class ParseUserAgent extends UDF {
+
+    private static final Parser PARSER = new Parser();
+
+    public Map<String,String> evaluate(final Text s) {
+        UserAgent userAgent = PARSER.parseUserAgent(s == null ? null : s.toString());
+
+        Map<String, String> map = new HashMap<String, String>(4);
+        if (userAgent != null) {
+            map.put("ua_family", userAgent.family);
+            map.put("ua_major", userAgent.major);
+            map.put("ua_minor", userAgent.minor);
+            map.put("ua_patch", userAgent.patch);
+        }
+        return map;
+    }
+}

--- a/src/test/java/ua_parser/ParserTest.java
+++ b/src/test/java/ua_parser/ParserTest.java
@@ -16,17 +16,18 @@
 
 package ua_parser;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
 import org.junit.Before;
+import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
-
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 /**
  * Tests parsing results match the expected results in the test_resources yamls
@@ -117,37 +118,55 @@ public class ParserTest {
   void testUserAgentFromYaml(String filename) {
     InputStream yamlStream = this.getClass().getResourceAsStream(TEST_RESOURCE_PATH + filename);
 
-    List<Map> testCases = (List<Map>) ((Map)yaml.load(yamlStream)).get("test_cases");
-    for(Map<String, String> testCase : testCases) {
-      // Skip tests with js_ua as those overrides are not yet supported in java
-      if (testCase.containsKey("js_ua")) continue;
+    try {
+      List<Map> testCases = (List<Map>) ((Map) yaml.load(yamlStream)).get("test_cases");
+      for (Map<String, String> testCase : testCases) {
+        // Skip tests with js_ua as those overrides are not yet supported in java
+        if (testCase.containsKey("js_ua")) continue;
 
-      String uaString = testCase.get("user_agent_string");
-      assertThat(uaString, parser.parseUserAgent(uaString), is(UserAgent.fromMap(testCase)));
+        String uaString = testCase.get("user_agent_string");
+        assertThat(uaString, parser.parseUserAgent(uaString), is(UserAgent.fromMap(testCase)));
+      }
+    } finally {
+      try {
+        yamlStream.close();
+      } catch (IOException ignored) {}
     }
   }
 
   void testOSFromYaml(String filename) {
     InputStream yamlStream = this.getClass().getResourceAsStream(TEST_RESOURCE_PATH + filename);
 
-    List<Map> testCases = (List<Map>) ((Map)yaml.load(yamlStream)).get("test_cases");
-    for(Map<String, String> testCase : testCases) {
-      // Skip tests with js_ua as those overrides are not yet supported in java
-      if (testCase.containsKey("js_ua")) continue;
+    try {
+      List<Map> testCases = (List<Map>) ((Map) yaml.load(yamlStream)).get("test_cases");
+      for (Map<String, String> testCase : testCases) {
+        // Skip tests with js_ua as those overrides are not yet supported in java
+        if (testCase.containsKey("js_ua")) continue;
 
-      String uaString = testCase.get("user_agent_string");
-      assertThat(uaString, parser.parseOS(uaString), is(OS.fromMap(testCase)));
+        String uaString = testCase.get("user_agent_string");
+        assertThat(uaString, parser.parseOS(uaString), is(OS.fromMap(testCase)));
+      }
+    } finally {
+      try {
+        yamlStream.close();
+      } catch (IOException ignored) {}
     }
   }
 
   void testDeviceFromYaml(String filename) {
     InputStream yamlStream = this.getClass().getResourceAsStream(TEST_RESOURCE_PATH + filename);
 
-    List<Map> testCases = (List<Map>) ((Map)yaml.load(yamlStream)).get("test_cases");
-    for(Map<String, String> testCase : testCases) {
+    try {
+      List<Map> testCases = (List<Map>) ((Map) yaml.load(yamlStream)).get("test_cases");
+      for (Map<String, String> testCase : testCases) {
 
-      String uaString = testCase.get("user_agent_string");
-      assertThat(uaString, parser.parseDevice(uaString), is(Device.fromMap(testCase)));
+        String uaString = testCase.get("user_agent_string");
+        assertThat(uaString, parser.parseDevice(uaString), is(Device.fromMap(testCase)));
+      }
+    } finally {
+      try {
+        yamlStream.close();
+      } catch (IOException ignored) {}
     }
   }
 


### PR DESCRIPTION
1. Make uap-core as git submodule of uap-java. So we can directly run `mvn package` in this project.
2. Add hive support. Hive-exec is added as a maven provided dependency.
3. Provide a shade plugin to create a uber jar for hive usage.
