### PR TITLE
Submodule use for development

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "uap-core"]
+	path = uap-core
+	url = https://github.com/ua-parser/uap-core.git

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <resources>
       <resource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/../uap-core</directory>
+        <directory>${basedir}/uap-core</directory>
         <includes>
           <include>regexes.yaml</include>
         </includes>
@@ -23,14 +23,14 @@
     <testResources>
       <testResource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/../uap-core/test_resources</directory>
+        <directory>${basedir}/uap-core/test_resources</directory>
         <includes>
           <include>*.yaml</include>
         </includes>
       </testResource>
       <testResource>
         <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/../uap-core/tests</directory>
+        <directory>${basedir}/uap-core/tests</directory>
         <includes>
           <include>*.yaml</include>
         </includes>


### PR DESCRIPTION
GIT has a new feature - submodules. This eases dependencies between projects. 
This PR is about adding uap-core as a reference to uap-java.
`# git clone --recursive git@github.com:JAlexoid/uap-java.git`
Will fetch all the necessary code to do a build. 

No need to clone all repositories separately.
