### PR TITLE
Added multithreaded version of caching parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
       <version>1.10</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>23.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.10</version>

--- a/src/main/java/ua_parser/MultithreadedCachingParser.java
+++ b/src/main/java/ua_parser/MultithreadedCachingParser.java
@@ -1,0 +1,127 @@
+package ua_parser;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class is multithreaded version of CachingParser.
+ *
+ * @author kyryloholodnov
+ */
+public class MultithreadedCachingParser extends Parser {
+
+    private static long cacheKeyExpiresAfterAccessMs = 24 * 60L * 60 * 1000; // 24 hours
+    private static long cacheMaximumSize = 1000;
+
+    private final LoadingCache<String, Client> cacheClient = CacheBuilder.newBuilder()
+            .expireAfterAccess(cacheKeyExpiresAfterAccessMs, TimeUnit.MILLISECONDS)
+            .maximumSize(cacheMaximumSize)
+            .build(new CacheLoader<String, Client>() {
+                @Override
+                @ParametersAreNonnullByDefault
+                public Client load(String agentString) throws Exception {
+                    return MultithreadedCachingParser.super.parse(agentString);
+                }
+            });
+
+    private final LoadingCache<String, UserAgent> cacheUserAgent = CacheBuilder.newBuilder()
+            .expireAfterAccess(cacheKeyExpiresAfterAccessMs, TimeUnit.MILLISECONDS)
+            .maximumSize(cacheMaximumSize)
+            .build(new CacheLoader<String, UserAgent>() {
+                @Override
+                @ParametersAreNonnullByDefault
+                public UserAgent load(String agentString) throws Exception {
+                    return MultithreadedCachingParser.super.parseUserAgent(agentString);
+                }
+            });
+
+    private final LoadingCache<String, Device> cacheDevice = CacheBuilder.newBuilder()
+            .expireAfterAccess(cacheKeyExpiresAfterAccessMs, TimeUnit.MILLISECONDS)
+            .maximumSize(cacheMaximumSize)
+            .build(new CacheLoader<String, Device>() {
+                @Override
+                @ParametersAreNonnullByDefault
+                public Device load(String agentString) throws Exception {
+                    return MultithreadedCachingParser.super.parseDevice(agentString);
+                }
+            });
+
+    private final LoadingCache<String, OS> cacheOS = CacheBuilder.newBuilder()
+            .expireAfterAccess(cacheKeyExpiresAfterAccessMs, TimeUnit.MILLISECONDS)
+            .maximumSize(cacheMaximumSize)
+            .build(new CacheLoader<String, OS>() {
+                @Override
+                @ParametersAreNonnullByDefault
+                public OS load(String agentString) throws Exception {
+                    return MultithreadedCachingParser.super.parseOS(agentString);
+                }
+            });
+
+    public MultithreadedCachingParser() throws IOException {
+        super();
+    }
+
+    public MultithreadedCachingParser(InputStream regexYaml) {
+        super(regexYaml);
+    }
+
+    @Override
+    public Client parse(String agentString) {
+        if (agentString == null) {
+            return null;
+        }
+        return cacheClient.getUnchecked(agentString);
+    }
+
+    @Override
+    public UserAgent parseUserAgent(String agentString) {
+        if (agentString == null) {
+            return null;
+        }
+        return cacheUserAgent.getUnchecked(agentString);
+    }
+
+    @Override
+    public Device parseDevice(String agentString) {
+        if (agentString == null) {
+            return null;
+        }
+        return cacheDevice.getUnchecked(agentString);
+    }
+
+    @Override
+    public OS parseOS(String agentString) {
+        if (agentString == null) {
+            return null;
+        }
+        return cacheOS.getUnchecked(agentString);
+    }
+
+    public static long getCacheKeyExpiresAfterAccessMs() {
+        return cacheKeyExpiresAfterAccessMs;
+    }
+
+    public static long getCacheMaximumSize() {
+        return cacheMaximumSize;
+    }
+
+    public static void setCacheMaximumSize(long cacheMaximumSize) {
+        if (cacheMaximumSize < 1) {
+            throw new IllegalArgumentException("Cache size should be positive value");
+        }
+        MultithreadedCachingParser.cacheMaximumSize = cacheMaximumSize;
+    }
+
+    public static void setCacheKeyExpiresAfterAccessMs(long cacheKeyExpiresAfterAccessMs) {
+        if (cacheKeyExpiresAfterAccessMs < 1) {
+            throw new IllegalArgumentException("Cache key expiration should be positive value");
+        }
+        MultithreadedCachingParser.cacheKeyExpiresAfterAccessMs = cacheKeyExpiresAfterAccessMs;
+    }
+}

--- a/src/test/java/ua_parser/MultithreadedCachingParserTest.java
+++ b/src/test/java/ua_parser/MultithreadedCachingParserTest.java
@@ -1,0 +1,86 @@
+package ua_parser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * These tests really only redo the same tests as in ParserTest but with a
+ * different Parser subclass Also the same tests will be run several times on
+ * the same user agents to validate the caching works correctly.
+ *
+ * @author kyryloholodnov
+ */
+public class MultithreadedCachingParserTest extends ParserTest {
+
+    @Before
+    public void initParser() throws Exception {
+        parser = new MultithreadedCachingParser();
+    }
+
+    @Override
+    Parser parserFromStringConfig(String configYamlAsString) throws Exception {
+        InputStream yamlInput = new ByteArrayInputStream(
+                configYamlAsString.getBytes("UTF8"));
+        return new CachingParser(yamlInput);
+    }
+
+    @Test
+    public void testCachedParseUserAgent() {
+        super.testParseUserAgent();
+        super.testParseUserAgent();
+        super.testParseUserAgent();
+    }
+
+    @Test
+    public void testCachedParseOS() {
+        super.testParseOS();
+        super.testParseOS();
+        super.testParseOS();
+    }
+
+    @Test
+    public void testCachedParseAdditionalOS() {
+        super.testParseAdditionalOS();
+        super.testParseAdditionalOS();
+        super.testParseAdditionalOS();
+    }
+
+    @Test
+    public void testCachedParseDevice() {
+        super.testParseDevice();
+        super.testParseDevice();
+        super.testParseDevice();
+    }
+
+    @Test
+    public void testCachedParseFirefox() {
+        super.testParseFirefox();
+        super.testParseFirefox();
+        super.testParseFirefox();
+    }
+
+    @Test
+    public void testCachedParsePGTS() {
+        super.testParsePGTS();
+        super.testParsePGTS();
+        super.testParsePGTS();
+    }
+
+    @Test
+    public void testCachedParseAll() {
+        super.testParseAll();
+        super.testParseAll();
+        super.testParseAll();
+    }
+
+    @Test
+    public void testCachedReplacementQuoting() throws Exception {
+        super.testReplacementQuoting();
+        super.testReplacementQuoting();
+        super.testReplacementQuoting();
+    }
+
+}


### PR DESCRIPTION
This version is necessary for multithreaded environment. LRUMap from org.apache.commons.collections.map can hang in multithreaded production environment which is fully reproducible in high load.