### PR TITLE
Update to support regex backreferences in all parsers. Fixes tests.

### DIFF
--- a/src/main/java/ua_parser/Parser.java
+++ b/src/main/java/ua_parser/Parser.java
@@ -16,18 +16,18 @@
 
 package ua_parser;
 
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
-
 /**
- * Java implementation of <a href="https://github.com/ua-parser">UA Parser</a>
+ * Java implementation of <a href="https://github.com/tobie/ua-parser">UA Parser</a>
  *
- * @author Steve Jiang (@sjiang) &lt;gh at iamsteve com&gt;
+ * @author Steve Jiang (@sjiang) <gh at iamsteve com>
  */
 public class Parser {
 
@@ -72,18 +72,18 @@ public class Parser {
     if (uaParserConfigs == null) {
       throw new IllegalArgumentException("user_agent_parsers is missing from yaml");
     }
-    uaParser = UserAgentParser.fromList(uaParserConfigs);
+    uaParser = new UserAgentParser(uaParserConfigs);
 
     List<Map<String,String>> osParserConfigs = regexConfig.get("os_parsers");
     if (osParserConfigs == null) {
       throw new IllegalArgumentException("os_parsers is missing from yaml");
     }
-    osParser = OSParser.fromList(osParserConfigs);
+    osParser = new OSParser(osParserConfigs);
 
     List<Map<String,String>> deviceParserConfigs = regexConfig.get("device_parsers");
     if (deviceParserConfigs == null) {
       throw new IllegalArgumentException("device_parsers is missing from yaml");
     }
-    deviceParser = DeviceParser.fromList(deviceParserConfigs);
+    deviceParser = new DeviceParser(deviceParserConfigs);
   }
 }

--- a/src/main/java/ua_parser/ReplacementCmd.java
+++ b/src/main/java/ua_parser/ReplacementCmd.java
@@ -1,0 +1,93 @@
+package ua_parser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Per: https://github.com/ua-parser/uap-core/blob/master/docs/specification.md
+ *
+ * Replacements to OS, Device  can be literal like "NT" or Regex Backreferences
+ * like $1, $2 or actually nothing, in which case the replcement can be extracted
+ * directly from the main regex match
+ *
+ * This class returns -given a matcher- what ua parser calls a replacement, the
+ * "value" assigned to that field given a match for a userAgent for OS or
+ * Device
+ */
+public class ReplacementCmd {
+
+    private static final Pattern SUBSTITUTIONS_PATTERN = Pattern.compile("\\$\\d");
+
+    private static ReplacementCmd instance = new ReplacementCmd();
+
+    public static ReplacementCmd getInstance(){
+        return instance;
+    }
+
+    /**
+     * Given an OS replacement like "NT" or "$1-S2" returns a value from the
+     * matcher
+     * Example:
+     * uastring: "Mozilla/5.0 (Windows; U; Win95; en-US; rv:1.1) Gecko/20020826"
+     * regex: 'Win(95|98|3.1|NT|ME|2000)'
+     * replacement: 'Windows $1'
+     * result of this method: 'Windows 95'
+     *
+     * @param replacement
+     * @param matcher
+     * @param groupCount
+     *
+     * @return
+     */
+    public String execute(String replacement, Matcher matcher, int groupCount){
+
+        String value = null;
+        if (replacement != null) {
+            // if there is a replcement given , explore what it might be
+            if (!replacement.contains("$")) {
+                // this is a literal replacement
+                value = replacement;
+            } else {
+                // this must be a regex backreference
+                value = getValueForRegex(replacement, matcher);
+            }
+        } else if (matcher.groupCount() >= groupCount) {
+            // the main regex migh have "()", return corresponding match
+            value = matcher.group(groupCount);
+        }
+        return value;
+    }
+
+
+    private String getValueForRegex(String replacement, Matcher matcher){
+
+        String value = replacement;
+
+        for (String substitution : splitRegexBackReferences(replacement)) {
+
+            // from $1 gets '1'
+            int backreference = Integer.valueOf(substitution.substring(1));
+
+            String _replacement = matcher.groupCount() >= backreference && matcher.group(backreference) != null
+                ? Matcher.quoteReplacement(matcher.group(backreference)) : "";
+            value = value.replaceFirst("\\" + substitution, _replacement);
+        }
+        return value.trim();
+    }
+
+    /**
+     * @param replacement String like "$1 - $2 "
+     *
+     * @return list($1, $2) where $1 and $2 are String literals
+     */
+    private List<String> splitRegexBackReferences(String replacement){
+        Matcher matcher = SUBSTITUTIONS_PATTERN.matcher(replacement);
+        List<String> substitutions = new ArrayList<String>();
+        while (matcher.find()) {
+            substitutions.add(matcher.group());
+        }
+        return substitutions;
+    }
+}

--- a/src/test/java/ua_parser/CachingParserTest.java
+++ b/src/test/java/ua_parser/CachingParserTest.java
@@ -1,10 +1,10 @@
 package ua_parser;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 /**
  * These tests really only redo the same tests as in ParserTest but with a
@@ -28,60 +28,48 @@ public class CachingParserTest extends ParserTest {
     return new CachingParser(yamlInput);
   }
 
+
+
   @Test
   public void testCachedParseUserAgent() {
     super.testParseUserAgent();
-    super.testParseUserAgent();
-    super.testParseUserAgent();
+
   }
 
   @Test
   public void testCachedParseOS() {
-    super.testParseOS();
-    super.testParseOS();
     super.testParseOS();
   }
 
   @Test
   public void testCachedParseAdditionalOS() {
     super.testParseAdditionalOS();
-    super.testParseAdditionalOS();
-    super.testParseAdditionalOS();
   }
 
   @Test
   public void testCachedParseDevice() {
-    super.testParseDevice();
-    super.testParseDevice();
     super.testParseDevice();
   }
 
   @Test
   public void testCachedParseFirefox() {
     super.testParseFirefox();
-    super.testParseFirefox();
-    super.testParseFirefox();
   }
 
   @Test
   public void testCachedParsePGTS() {
-    super.testParsePGTS();
-    super.testParsePGTS();
     super.testParsePGTS();
   }
 
   @Test
   public void testCachedParseAll() {
     super.testParseAll();
-    super.testParseAll();
-    super.testParseAll();
   }
 
   @Test
-  public void testCachedReplacementQuoting() throws Exception {
-    super.testReplacementQuoting();
-    super.testReplacementQuoting();
+  public void testCachedReplacementQuoting() throws Exception{
     super.testReplacementQuoting();
   }
+
 
 }


### PR DESCRIPTION
Per specification replacements could be regex back references:
https://github.com/ua-parser/uap-core/blob/master/docs/specification.md

We have consolidated the code that deals with back references so it can be used by any parser to an
external class.

This commit fixes the tests that otherwise will be broken with the latest version of ua-core and removes some extra code thatwas not needed for initialization of parsers for clarity.