### PR TITLE
Use dependencies for yaml files from uap-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,33 +56,6 @@
   </properties>
   
   <build>
-    <resources>
-      <resource>
-        <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/uap-core</directory>
-        <includes>
-          <include>regexes.yaml</include>
-        </includes>
-      </resource>
-    </resources>
-    
-    <testResources>
-      <testResource>
-        <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/uap-core/test_resources</directory>
-        <includes>
-          <include>*.yaml</include>
-        </includes>
-      </testResource>
-      <testResource>
-        <targetPath>ua_parser</targetPath>
-        <directory>${basedir}/uap-core/tests</directory>
-        <includes>
-          <include>*.yaml</include>
-        </includes>
-      </testResource>
-    </testResources>
-    
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -149,6 +122,20 @@
   </profiles>
   
   <dependencies>
+    <dependency>
+      <groupId>com.github.ua-parser</groupId>
+      <artifactId>uap-core</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ua-parser</groupId>
+      <artifactId>uap-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
We would like to use uap-java in the keycloak project (https://www.keycloak.org). However, to do so I need to make a change to your build system. Would my proposed changes be acceptable to you?