### PR TITLE
Adding Jackson databind module for simplified deserialization.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
   <build>
     <resources>
       <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
         <targetPath>ua_parser</targetPath>
         <directory>${basedir}/uap-core</directory>
         <includes>
@@ -67,6 +70,9 @@
     </resources>
     
     <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
       <testResource>
         <targetPath>ua_parser</targetPath>
         <directory>${basedir}/uap-core/test_resources</directory>
@@ -160,6 +166,12 @@
       <version>4.1</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.3</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -169,6 +181,18 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/ua_parser/ClientModule.java
+++ b/src/main/java/ua_parser/ClientModule.java
@@ -1,0 +1,62 @@
+package ua_parser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Class that registers capability of serializing objects with Jackson core.
+ *
+ * This module can be manually registered with Jackson:
+ * <pre>
+ *     ObjectMapper mapper = new ObjectMapper();
+ *     mapper.registerModule(new ClientModule());
+ * </pre>
+ *
+ * This module also supports auto configuration as an SPI via the Java ServiceLoader api:
+ * <pre>
+ *     ObjectMapper mapper = new ObjectMapper();
+ *     mapper.findAndRegisterModules();
+ *
+ * </pre>
+ *
+ * @author Adam J. Weigold
+ */
+public class ClientModule extends SimpleModule {
+
+    public ClientModule() {
+        setMixInAnnotation(UserAgent.class, UserAgentMixin.class);
+        setMixInAnnotation(OS.class, OSMixin.class);
+        setMixInAnnotation(Device.class, DeviceMixin.class);
+        setMixInAnnotation(Client.class, ClientMixin.class);
+    }
+
+    abstract static class UserAgentMixin {
+        @JsonCreator
+        public UserAgentMixin(@JsonProperty("family") String family,
+                              @JsonProperty("major") String major,
+                              @JsonProperty("minor") String minor,
+                              @JsonProperty("patch") String patch) {}
+    }
+
+    abstract static class OSMixin {
+        @JsonCreator
+        public OSMixin(@JsonProperty("family") String family,
+                       @JsonProperty("major") String major,
+                       @JsonProperty("minor") String minor,
+                       @JsonProperty("patch") String patch,
+                       @JsonProperty("patchMinor") String patchMinor) {}
+    }
+
+    abstract static class DeviceMixin {
+        @JsonCreator
+        public DeviceMixin(@JsonProperty("family") String family) {}
+    }
+
+    abstract static class ClientMixin {
+        @JsonCreator
+        public ClientMixin(@JsonProperty("userAgent") UserAgent userAgent,
+                           @JsonProperty("os") OS os,
+                           @JsonProperty("device") Device device) {}
+    }
+}

--- a/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,1 @@
+ua_parser.ClientModule

--- a/src/test/java/ua_parser/JacksonModuleDatabindingTest.java
+++ b/src/test/java/ua_parser/JacksonModuleDatabindingTest.java
@@ -1,0 +1,43 @@
+package ua_parser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JacksonModuleDatabindingTest {
+
+    @Test
+    public void testJacksonModuleSpiRegistration() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+        Class<?> clientMixin = objectMapper.findMixInClassFor(Client.class);
+        assertTrue(clientMixin.isAssignableFrom(ClientModule.ClientMixin.class));
+    }
+
+    @Test
+    public void testJacksonSerializationAndDeserialization() throws IOException, JSONException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+
+        Client testClient = new Client(new UserAgent("Firefox", "3", "5", "5"),
+                new OS("Mac OS X", "10", "4", null, null),
+                new Device("Other"));
+
+        String expectedSerialization = IOUtils.resourceToString(
+                "ua_parser/testClient.json", Charset.defaultCharset(), getClass().getClassLoader());
+
+        String actualSerialization = objectMapper.writeValueAsString(testClient);
+        JSONAssert.assertEquals(expectedSerialization, actualSerialization, true);
+
+        Client deserializedClient = objectMapper.readValue(actualSerialization, Client.class);
+        assertEquals(testClient, deserializedClient);
+    }
+}

--- a/src/test/resources/ua_parser/testClient.json
+++ b/src/test/resources/ua_parser/testClient.json
@@ -1,0 +1,18 @@
+{
+  "userAgent": {
+    "family": "Firefox",
+    "major": "3",
+    "minor": "5",
+    "patch": "5"
+  },
+  "os": {
+    "family": "Mac OS X",
+    "major": "10",
+    "minor": "4",
+    "patch": null,
+    "patchMinor": null
+  },
+  "device": {
+    "family": "Other"
+  }
+}


### PR DESCRIPTION
This commit adds compile only dependencies to Jackson databind, to
provide simplified deserialization of ua_parser models for consumers
using the library.

As this is compile only, no impact is expected to consumers not using
Jackson.  However by including this boilerplate code, Jackson now can
deserialize directly into ua_parser models in projects that may have
stored them previously.