### PR TITLE
Make uap java an osgi bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .project
 .vscode
 .settings
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.ua-parser</groupId>
   <artifactId>uap-java</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <version>1.4.4-SNAPSHOT</version>
   <name>User Agent Parser for Java</name>
   
@@ -92,6 +92,12 @@
           <source>1.7</source>
           <target>1.7</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>4.2.1</version>
+        <extensions>true</extensions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
See issue #46 
The maven bundle plugin can be used easily to generate the bundle information.
The resulting jar can then be used the normal way as before as well as an OSGI bundle.
