### PR TITLE
Fix build for project and failing tests to reflect latest uap-core/regexes.yaml changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,33 @@
   </properties>
   
   <build>
+    <resources>
+      <resource>
+        <targetPath>ua_parser</targetPath>
+        <directory>${basedir}/uap-core</directory>
+        <includes>
+          <include>regexes.yaml</include>
+        </includes>
+      </resource>
+    </resources>
+
+    <testResources>
+      <testResource>
+        <targetPath>ua_parser</targetPath>
+        <directory>${basedir}/uap-core/test_resources</directory>
+        <includes>
+          <include>*.yaml</include>
+        </includes>
+      </testResource>
+      <testResource>
+        <targetPath>ua_parser</targetPath>
+        <directory>${basedir}/uap-core/tests</directory>
+        <includes>
+          <include>*.yaml</include>
+        </includes>
+      </testResource>
+    </testResources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -122,6 +149,7 @@
   </profiles>
   
   <dependencies>
+<!--
     <dependency>
       <groupId>com.github.ua-parser</groupId>
       <artifactId>uap-core</artifactId>
@@ -136,6 +164,7 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+-->
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>

--- a/src/test/java/ua_parser/ParserTest.java
+++ b/src/test/java/ua_parser/ParserTest.java
@@ -81,7 +81,7 @@ public class ParserTest {
 
     Client expected1 = new Client(new UserAgent("Firefox", "3", "5", "5"),
                                   new OS("Mac OS X", "10", "4", null, null),
-                                  new Device("Other"));
+                                  new Device("Mac"));
     Client expected2 = new Client(new UserAgent("Mobile Safari", "5", "1", null),
                                   new OS("iOS", "5", "1", "1", null),
                                   new Device("iPhone"));


### PR DESCRIPTION
Fix build for project by reverting pom.xml (remove jar dependency point to submodule path); update failing tests to reflect latest changes to uap-core/regexes.yaml (fix go re2 compatible issue	f4d6e96	jnozsc <jnozsc@gmail.com>	Feb 11, 2020 at 3:50 AM)