### PR TITLE
Update org.yaml:snakeyaml from 1.20 to 1.26  to resolve security vulnerability 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.20</version>
+      <version>1.26</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Vulnerability has been reported in the library SnakeYAML.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18640

The problem is fixed at Ver 1.26 of the lib.
https://bitbucket.org/asomov/snakeyaml/commits/da11ddbd91c1f8392ea932b37fa48110fa54ed8c
https://bitbucket.org/asomov/snakeyaml/issues/377/allow-configuration-for-preventing-billion

So please update SnakeYAML version.