### PR TITLE
Bumped snakeyaml to 1.31 to mitigate CVE-2022-25857

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.26</version>
+      <version>1.31</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Hi There,

Our project is using this great piece of library, but the OWASP dep. checker has noticed that the version of snakeyaml you're using has a vulnerability. (CVE-2022-25857)

What I did:
- Bumped the version to the latest in the pom.xml
- Built the project and executed the unit tests. _(mvn test)_ It checked out all fine so I'm assuming that the new version's compatible with the uap-java.